### PR TITLE
Added ability to update Boolean, DateTime and Lookup attributes.

### DIFF
--- a/Cinteros.XTB.BulkDataUpdater/MainControl.cs
+++ b/Cinteros.XTB.BulkDataUpdater/MainControl.cs
@@ -647,17 +647,50 @@
                 case AttributeTypeCode.String:
                 case AttributeTypeCode.Memo:
                     return cmbValue.Text;
-                    break;
+
                 case AttributeTypeCode.BigInt:
                 case AttributeTypeCode.Integer:
                     return int.Parse(cmbValue.Text);
-                    break;
+
                 case AttributeTypeCode.Picklist:
                 case AttributeTypeCode.State:
                 case AttributeTypeCode.Status:
                     var value = ((OptionsetItem)cmbValue.SelectedItem).meta.Value;
                     return new OptionSetValue((int)value);
-                    break;
+
+                case AttributeTypeCode.DateTime:
+                    return DateTime.Parse(cmbValue.Text);
+
+                case AttributeTypeCode.Boolean:
+                    {
+                        // Is checking the cmbAttribute ok? I hope so...
+                        var attr = (BooleanAttributeMetadata)((AttributeItem)cmbAttribute.SelectedItem).Metadata;
+                        return ((OptionsetItem)cmbValue.SelectedItem).meta == attr.OptionSet.TrueOption;
+                    }
+
+                // The following allows to specify an entity reference in the following form:
+                // attribute_name,attribute_guid
+                // eg: account,08e943f8-1ff0-41ea-89c0-5478dd465806
+                // As a security check, the attribute_name MUST be in the targets 
+                // specified by the lookup attribute metadata targets
+                case AttributeTypeCode.Lookup:
+                    {
+                        // Get the attribute metadata for the lookup type:
+                        var attr = (LookupAttributeMetadata)((AttributeItem)cmbAttribute.SelectedItem).Metadata;
+
+                        // split the text: first part: attribute meta name, second part: attribute guid to update
+                        var t = cmbValue.Text.Split(',', ';', '/', '\\', ':').ToArray();
+                        // get the first target
+                        string attrname = (attr.Targets != null && attr.Targets.Length > 0) ? attr.Targets[0] : null;
+                        if (attr.Targets != null && t.Length > 1)
+                            attrname = attr.Targets.FirstOrDefault(x => t.First().Equals(x, StringComparison.OrdinalIgnoreCase));
+
+                        if (String.IsNullOrEmpty(attrname))
+                            throw new Exception("Target entity: '" + t.First() + "' is null or not found");
+
+                        return new EntityReference(attrname, new Guid(t.Last()));
+                    }
+
                 default:
                     throw new Exception("Attribute of type " + type.ToString() + " is currently not supported.");
             }
@@ -678,6 +711,16 @@
                         {
                             cmbValue.Items.Add(new OptionsetItem(option));
                         }
+                    }
+                    cmbValue.DropDownStyle = ComboBoxStyle.DropDownList;
+                }
+                else if (attribute.Metadata is BooleanAttributeMetadata)
+                {
+                    var options = ((BooleanAttributeMetadata)attribute.Metadata).OptionSet;
+                    if (options != null)
+                    {
+                        cmbValue.Items.Add(new OptionsetItem(options.TrueOption));
+                        cmbValue.Items.Add(new OptionsetItem(options.FalseOption));
                     }
                     cmbValue.DropDownStyle = ComboBoxStyle.DropDownList;
                 }


### PR DESCRIPTION
With this commit the plugin is able to update boolean, datetime and lookup attributes.
The boolean values are shown as items of combobox, the datetime is simply parsed.
The lookup value should be rewritten, this edit allows to specify an entity reference in the following form: `attribute_name,attribute_guid`
eg: `account,08e943f8-1ff0-41ea-89c0-5478dd465806`
As a security check, the `attribute_name` MUST be in the targets specified by the attribute metadata.
The Lookup and DateTime should, however, be displayed in a alternate form: a DateTime picker for datetime values and target selector plus guid validator for lookup).
